### PR TITLE
Deep copy point cloud.

### DIFF
--- a/aerial_mapper_demos/src/dsm/main-dsm.cc
+++ b/aerial_mapper_demos/src/dsm/main-dsm.cc
@@ -87,7 +87,6 @@ int main(int argc, char** argv) {
     stereo::BlockMatchingParameters block_matching_params;
     block_matching_params.use_BM = FLAGS_use_BM;
     stereo::Stereo stereo(ncameras, settings_dense_pcl, block_matching_params);
-    AlignedType<std::vector, Eigen::Vector3d>::type point_cloud;
     stereo.addFrames(T_G_Bs, images, &point_cloud);
   }
 

--- a/aerial_mapper_dense_pcl/src/stereo.cpp
+++ b/aerial_mapper_dense_pcl/src/stereo.cpp
@@ -176,8 +176,10 @@ void Stereo::processStereoFrame(
   densifier_->computePointCloud(stereo_rig_params_, rectified_stereo_pair,
                                 &densified_stereo_pair, point_cloud_ros_msg_);
   *point_cloud = densified_stereo_pair.point_cloud_eigen;
-  *point_cloud_intensities = densified_stereo_pair.point_cloud_intensities;
-
+  if (point_cloud_intensities) {
+    *point_cloud_intensities = densified_stereo_pair.point_cloud_intensities;
+  }
+  
   // 5. Publish the point cloud.
   pub_point_cloud_.publish(point_cloud_ros_msg_);
   ros::spinOnce();

--- a/aerial_mapper_dense_pcl/src/stereo.cpp
+++ b/aerial_mapper_dense_pcl/src/stereo.cpp
@@ -173,10 +173,10 @@ void Stereo::processStereoFrame(
                                    point_cloud_ros_msg_.height);
   ros::Time timestamp = ros::Time::now();
   point_cloud_ros_msg_.header.stamp = timestamp;
-  point_cloud = &densified_stereo_pair.point_cloud_eigen;
-  point_cloud_intensities = &densified_stereo_pair.point_cloud_intensities;
   densifier_->computePointCloud(stereo_rig_params_, rectified_stereo_pair,
                                 &densified_stereo_pair, point_cloud_ros_msg_);
+  *point_cloud = densified_stereo_pair.point_cloud_eigen;
+  *point_cloud_intensities = densified_stereo_pair.point_cloud_intensities;
 
   // 5. Publish the point cloud.
   pub_point_cloud_.publish(point_cloud_ros_msg_);


### PR DESCRIPTION
- Deep copy of point cloud to pass it on.

Fixes DSM in demo `0-synthetic-cadastre-dsm.launch`. 
![rviz_screenshot_2018_02_13-14_43_56](https://user-images.githubusercontent.com/11293852/36153957-3736708e-10d0-11e8-8b3a-10a8bbe13b06.png)

To avoid deep copying I would suggest either
- making  [point cloud data](https://github.com/ethz-asl/aerial_mapper/blob/master/aerial_mapper_dense_pcl/include/aerial-mapper-dense-pcl/common.h#L77-L78) shared pointer or
- making [DensifiedStereoPair](https://github.com/ethz-asl/aerial_mapper/blob/master/aerial_mapper_dense_pcl/src/stereo.cpp#L166) shared pointer.

What do you think?