### PR TITLE
Add github actions and solve build error

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,66 @@
+name: Build Test
+on:
+  push:
+    branches:
+    - 'master'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {rosdistro: 'kinetic', container: 'px4io/px4-dev-ros-kinetic:2020-07-18'} 
+          - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2020-08-14'}
+    container: ${{ matrix.config.container }}
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Prepare ccache timestamp
+      id: ccache_cache_timestamp
+      shell: cmake -P {0}
+      run: |
+        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+        message("::set-output name=timestamp::${current_date}")
+    - name: ccache cache files
+      uses: actions/cache@v2
+      with:
+        path: ~/.ccache
+        key: sitl_tests-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
+        restore-keys: sitl_tests-ccache-
+    - name: setup ccache
+      run: |
+          mkdir -p ~/.ccache
+          echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
+          echo "compression = true" >> ~/.ccache/ccache.conf
+          echo "compression_level = 6" >> ~/.ccache/ccache.conf
+          echo "max_size = 800M" >> ~/.ccache/ccache.conf
+          ccache -s
+          ccache -z
+    - name: release_build_test
+      working-directory: 
+      run: |
+        apt update
+        apt install -y python3-wstool libgdal-dev autoconf libtool libtool-bin libcurlpp-dev libcurl4-openssl-dev
+        mkdir -p $HOME/catkin_ws/src;
+        cd $HOME/catkin_ws
+        catkin init
+        catkin config --extend "/opt/ros/${{matrix.config.rosdistro}}"
+        catkin config --merge-devel
+        cd $HOME/catkin_ws/src
+        ln -s $GITHUB_WORKSPACE
+        cd $HOME/catkin_ws
+        wstool init src src/aerial_mapper/install/dependencies_https.rosinstall
+        wstool update -t src -j4
+        rosdep update
+        rosdep install --from-paths src --ignore-src -y --rosdistro ${{matrix.config.rosdistro}}
+        catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release
+        catkin build -j$(nproc) -l$(nproc) aerial_mapper -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+    - name: ccache post-run
+      run: ccache -s

--- a/aerial_mapper_io/src/aerial-mapper-io.cc
+++ b/aerial_mapper_io/src/aerial-mapper-io.cc
@@ -251,10 +251,10 @@ void AerialMapperIO::loadImagesFromFile(
 aslam::NCamera::Ptr AerialMapperIO::loadCameraRigFromFile(
     const std::string& filename_ncameras_yaml) {
   CHECK(filename_ncameras_yaml != "");
-  aslam::NCamera::Ptr ncameras;
+  aslam::NCamera::Ptr ncameras(new aslam::NCamera());
   LOG(INFO) << "Loading camera calibration from: "
             << filename_ncameras_yaml;
-  ncameras = aslam::NCamera::loadFromYaml(filename_ncameras_yaml);
+  ncameras->deserializeFromFile(filename_ncameras_yaml);
   CHECK(ncameras) << "Could not load the camera calibration from: "
                   << filename_ncameras_yaml;
  return ncameras;

--- a/install/dependencies_https.rosinstall
+++ b/install/dependencies_https.rosinstall
@@ -13,3 +13,9 @@
 - git: {local-name: pcl_catkin, uri: 'https://github.com/ethz-asl/pcl_catkin.git'}
 - git: {local-name: vision_opencv, uri: 'https://github.com/ethz-asl/vision_opencv.git'}
 - git: {local-name: yaml_cpp_catkin, uri: 'https://github.com/ethz-asl/yaml_cpp_catkin.git'}
+- git: {local-name: protobuf_catkin, uri: 'https://github.com/ethz-asl/protobuf_catkin.git'}
+- git: {local-name: ethzasl_apriltag2, uri: 'https://github.com/ethz-asl/ethzasl_apriltag2.git'}
+- git: {local-name: numpy_eigen, uri: 'https://github.com/ethz-asl/numpy_eigen.git'}
+- git: {local-name: libnabo, uri: 'https://github.com/ethz-asl/libnabo.git'}
+- git: {local-name: catkin_boost_python_buildtool, uri: 'https://github.com/ethz-asl/catkin_boost_python_buildtool.git'}
+- git: {local-name: opengv, uri: 'https://github.com/ethz-asl/opengv.git'}


### PR DESCRIPTION
**Problem Description**
This PR adds the a build fix which seems to be caused by a regression coming from a aslam_cv2 update. The fix has been mentioned in https://github.com/ethz-asl/aerial_mapper/issues/43 and is included in this PR

To prevent this from happening a gain, a github actions CI has been added which verifies the build in the following Ubuntu distributions. The Jenkins build pipeline uisng Jenkins seems to be not running anymore. 
- Ubuntu 16.04 Xenial ROS Kinetic 
- Ubuntu 18.04 Bionic ROS Melodic

**Additional Context**
- The build takes extremely long, probably we need to start packaging and distributing some of the build dependencies (e.g. pcl_catkin)
- This package fails to resolve dependencies on ROS Noetic and seems like it is coming from other dependencies too: https://github.com/Jaeyoung-Lim/aerial_mapper/pull/1/checks?check_run_id=1553005334
- Fixes https://github.com/ethz-asl/aerial_mapper/issues/43
- Fixes https://github.com/ethz-asl/aerial_mapper/issues/42 with the added rosinstall dependencies
